### PR TITLE
apply text replace to stop_name

### DIFF
--- a/MMM-transitfeed.js
+++ b/MMM-transitfeed.js
@@ -234,6 +234,7 @@ Module.register("MMM-transitfeed", {
         // Convert stop_time back to a Date (lost in serialization from backend
         for (trip of trips) {
             trip.stop_time = new Date(trip.stop_time);
+            trip.stop_name = this.tr(trip.stop_name);
             trip.route_name = this.tr(trip.route_name);
             trip.trip_terminus = this.tr(trip.trip_terminus);
             trip.route_id = this.tr(trip.route_id);


### PR DESCRIPTION
I ran into a case where a stop had distinct names for each direction, one with a period at the end, one without. 

<img width="390" height="125" alt="Screenshot from 2025-08-28 18-34-34" src="https://github.com/user-attachments/assets/8b048aa0-1c77-41aa-b23e-cbc863acae7b" />
<img width="390" height="108" alt="Screenshot from 2025-08-28 18-34-48" src="https://github.com/user-attachments/assets/196a00f7-c8c8-4063-ad92-d66ace83815c" />

Applying text replacement to each trip's stop_name allowed those 2 stops to be consolidated when the replace config was set as follows:

```
    replace: {
        '.': '',
    },
```

Thought I'd share in case you're interested in incorporating. 